### PR TITLE
Fixing CouchDB public server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Before using this code, you must have the following prerequisites installed
 ### The Easy Way
 
 Create a database on your local CouchDB instance, and clone the code from
-the server http://couchdb.loris.ca:5984/dataquerytool-$VERSION where $VERSION
+the server https://couchdb.loris.ca:5984/dataquerytool-$VERSION where $VERSION
 is separated by underscores rather than dots (because dots are not allowed
 in CouchDB database names.)
 
 ie.
 
 ```bash
-curl -H 'Content-Type: application/json' -X POST http://$YOURCOUCHDBADMIN:$YOURCOUCHADMINPASS@$YOURSERVERNAME:5984/_replicate -d '{"source":"http://couchdb.loris.ca:5984/dataquerytool-1_0_0", "target":"$YOURDATABASENAME"}'
+curl -H 'Content-Type: application/json' -X POST http://$YOURCOUCHDBADMIN:$YOURCOUCHADMINPASS@$YOURSERVERNAME:5984/_replicate -d '{"source":"https://couchdb.loris.ca:5984/dataquerytool-1_0_0", "target":"$YOURDATABASENAME"}'
 ```
 
 ### The Hard Way (for development)


### PR DESCRIPTION
Changing links for the public couchdb server to https instead of http